### PR TITLE
Tools for making a Pypi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ build
 dist
 README.html
 nostril.egg-info
+casics_nostril.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+install-release-tools:
+	pip install --user twine
+
+release:
+	python setup.py sdist
+	python setup.py bdist_wheel --universal
+	twine check dist/*
+	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 install-release-tools:
 	pip install --user twine
 
-release:
+release-pypi-test:
+	python setup.py sdist
+	python setup.py bdist_wheel --universal
+	twine check dist/*
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+release-pypi:
 	python setup.py sdist
 	python setup.py bdist_wheel --universal
 	twine check dist/*

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please also use the DOI to indicate the specific version you use, to improve oth
 
 The following is probably the simplest and most direct way to install Nostril on your computer:
 ```
-sudo pip3 install git+https://github.com/casics/nostril.git
+sudo pip3 install casics-nostril
 ```
 
 Alternatively, you can clone this repository and then run `setup.py`:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,12 @@ with open(path.join(here, 'nostril/__version__.py')) as f:
 # Finally, define our namesake.
 
 setup(
-    name             = version['__title__'].lower(),
+    # We use an alternative name (casics-nostril) on PyPi,
+    # as nostril is already used by https://pypi.org/project/nostril/
+    # Users will have to use pip install casics-nostril,
+    # but it won't change the installed package name (nostril),
+    # which is defined in the packages property.
+    name             = "casics-{}".format(version['__title__'].lower()),
     description      = version['__description__'],
     long_description = readme_markdown,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'requirements.txt')) as f:
     reqs = f.read().rstrip().splitlines()
 
+with open("README.md") as f:
+    readme_markdown = f.read()
+
 # The following reads the variables without doing an "import nostril",
 # because the latter will cause the python execution environment to fail if
 # any dependencies are not already installed -- negating most of the reason
@@ -35,7 +38,8 @@ with open(path.join(here, 'nostril/__version__.py')) as f:
 setup(
     name             = version['__title__'].lower(),
     description      = version['__description__'],
-    long_description = 'Nostril (Nonsense String Evaluator) implements a heuristic mechanism to infer whether a given word or text string is likely to be meaningful or nonsense.',
+    long_description = readme_markdown,
+    long_description_content_type="text/markdown",
     version          = version['__version__'],
     url              = version['__url__'],
     author           = version['__author__'],


### PR DESCRIPTION
Fixes #1 

The PR add Makefile targets for releasing the package to Pypi.

To make the release, you simply have:
* to create an account on [Pypi](https://pypi.org/);
* run `make release-pypi` and provides your Pypi credentials.

It relies on [twine](https://github.com/pypa/twine) to upload the package. The procedure has been tested on the Test Pypi repository and seems to work fine: https://test.pypi.org/project/monsieurv-nostril/.

Note: as `nostril` has already have been [taken](https://pypi.org/project/nostril/) on the Pypi repository, I suggested to make the name `casics-nostril` on Pypy (of course you can change it as you wish!).
As commented in the `setup.py`, this won't change the name of the installed package (user would still do `from nostril import nonsense` as in the doc), only the name used for the pip install (`pip install casics-nostril`).

@mhucka :pray: 